### PR TITLE
add bucket dependency 

### DIFF
--- a/aws/stacks/archive.ts
+++ b/aws/stacks/archive.ts
@@ -66,7 +66,7 @@ export class ArchiveStack extends cdk.Stack {
       path: '/service-role/'
     });
 
-    new cdk.CfnStackSet(this, "StackSet", {
+    const stackSet = new cdk.CfnStackSet(this, "StackSet", {
       stackSetName: `${props.prefix}-archive-replication`,
       permissionModel: "SELF_MANAGED",
       parameters: [
@@ -195,7 +195,9 @@ export class ArchiveStack extends cdk.Stack {
           }
         )
       )
-    }
+    };
+
+    cfnBucket.addDependsOn(stackSet);
 
     new cdk.CfnOutput(this, 'BucketName', { value: bucket.bucketName })
     new cdk.CfnOutput(this, 'BucketRegion', { value: this.region })


### PR DESCRIPTION
Adding a dependency to the StackSet prevents `Destination bucket must exist` errors.